### PR TITLE
fix: Update `goheader` linter setting to support 2024 and onwards

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,7 +7,9 @@ linters-settings:
     values:
       const:
         COMPANY: Cofide Limited
+      regexp:
+        VALID_YEAR: 202[4-9]|20[3-9][0-9]|2[1-9][0-9][0-9]
     # Require Cofide copyright and SPDX license in all source files.
-    template: |
-      Copyright {{ MOD-YEAR }} {{ COMPANY }}.
+    template: |-
+      Copyright {{ VALID_YEAR }} {{ COMPANY }}.
       SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Summary
- This PR adds a small fix to the `goheader` linter setting in `.golangci.yaml` to allow all years from 2024 and onwards to be valid, as discussed [here](https://github.com/cofide/cofidectl-debug-container/pull/8#issuecomment-2567846073).