### PR TITLE
Update the format of the xDS resource name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofide-sdk-go
 
-go 1.24.0
+go 1.24.2
 
 require (
 	github.com/envoyproxy/go-control-plane v0.13.4


### PR DESCRIPTION
In the Cofide Agent xDS server, which can be used with `EXPERIMENTAL_XDS_SERVER_URI`, Clusters have a "_cluster" suffix. This PR uses this format for the xDS resource name.