### PR TITLE
fix: bump Go to 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofide-sdk-go
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/envoyproxy/go-control-plane v0.13.4


### PR DESCRIPTION
This brings in fixes for GO-2025-3751, GO-2025-3750, GO-2025-3749.
