### PR TITLE
fix: use BundleSource in MTLSClientConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/cofide-sdk-go
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/envoyproxy/go-control-plane v0.13.4

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -91,7 +91,7 @@ func NewClient(opts ...ClientOption) *Client {
 	c.EnsureSPIRE()
 	c.WaitReady()
 
-	tlsConfig := tlsconfig.MTLSClientConfig(c.X509Source, c.X509Source, c.Authorizer)
+	tlsConfig := tlsconfig.MTLSClientConfig(c.X509Source, c.BundleSource, c.Authorizer)
 	c.Transport = createTransport(tlsConfig)
 
 	return c

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -4,7 +4,6 @@
 package backoff
 
 import (
-	"math"
 	"sync"
 	"time"
 )
@@ -51,14 +50,14 @@ func (b *Backoff) Duration() time.Duration {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
-	backoff := float64(b.n) + 1
-	d := math.Pow(2, backoff) * float64(b.InitialDelay)
-	if d > float64(b.MaxDelay) {
-		d = float64(b.MaxDelay)
+	d := b.InitialDelay << b.n
+	// Check for overflow (d becomes non-positive) or if it exceeds MaxDelay.
+	if d < 0 || d > b.MaxDelay {
+		d = b.MaxDelay
 	}
 
 	b.n++
-	return time.Duration(d) * time.Second
+	return time.Duration(d)
 }
 
 // Reset resets the backoff's state.

--- a/internal/backoff/backoff_test.go
+++ b/internal/backoff/backoff_test.go
@@ -1,0 +1,48 @@
+// Copyright 2024 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package backoff
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackoff_defaults(t *testing.T) {
+	backoff := NewBackoff()
+	expectedDurations := []time.Duration{
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		800 * time.Millisecond,
+	}
+	for _, expected := range expectedDurations {
+		assert.Equal(t, expected, backoff.Duration())
+	}
+	backoff.Reset()
+	assert.Equal(t, 200*time.Millisecond, backoff.Duration())
+}
+
+func TestBackoff_maxDelay(t *testing.T) {
+	backoff := NewBackoff(WithInitialDelay(time.Second), WithMaxDelay(5*time.Second))
+	expectedDurations := []time.Duration{
+		time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		5 * time.Second,
+		5 * time.Second,
+	}
+	for _, expected := range expectedDurations {
+		assert.Equal(t, expected, backoff.Duration())
+	}
+	backoff.Reset()
+	assert.Equal(t, time.Second, backoff.Duration())
+}
+
+func TestBackoff_overflow(t *testing.T) {
+	backoff := NewBackoff(WithInitialDelay(math.MaxInt64-1), WithMaxDelay(math.MaxInt64))
+	assert.Equal(t, time.Duration(math.MaxInt64-1), backoff.Duration())
+	assert.Equal(t, time.Duration(math.MaxInt64), backoff.Duration())
+}

--- a/internal/spirehelper/spire.go
+++ b/internal/spirehelper/spire.go
@@ -18,9 +18,10 @@ import (
 const defaultSPIRESocketAddr = "unix:///tmp/spire.sock"
 
 type SPIREHelper struct {
-	X509Source *workloadapi.X509Source
-	SPIREAddr  string
-	Ctx        context.Context
+	X509Source   *workloadapi.X509Source
+	BundleSource *workloadapi.BundleSource
+	SPIREAddr    string
+	Ctx          context.Context
 
 	Authorizer tlsconfig.Authorizer
 
@@ -68,6 +69,13 @@ func (s *SPIREHelper) EnsureSPIRE() {
 				time.Sleep(s.backoff.Duration())
 				continue
 			}
+
+			s.BundleSource, err = workloadapi.NewBundleSource(s.Ctx, workloadapi.WithClientOptions(workloadapi.WithAddr(s.SPIREAddr)))
+			if err != nil {
+				time.Sleep(s.backoff.Duration())
+				continue
+			}
+
 			s.backoff.Reset()
 
 			break


### PR DESCRIPTION
This ensures we send intermediate certificates.
