### PR TITLE
fix: Ack endpoint discovery

### DIFF
--- a/http/client/client.go
+++ b/http/client/client.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"time"
@@ -116,6 +117,7 @@ func (c *Client) initTransport(tlsConfig *tls.Config) (http.RoundTripper, error)
 	}
 
 	xdsClient, err := xds.NewXDSClient(xds.XDSClientConfig{
+		Logger:    slog.Default(),
 		ServerURI: c.xdsServerURI,
 		NodeID:    c.xdsNodeID,
 	})

--- a/internal/xds/client.go
+++ b/internal/xds/client.go
@@ -149,6 +149,7 @@ func (c *XDSClient) watchEndpoints(ctx context.Context, logger *slog.Logger, ser
 				var cla endpoint.ClusterLoadAssignment
 				if err := resp.Resources[0].UnmarshalTo(&cla); err != nil {
 					logger.Error("Failed to unmarshal ClusterLoadAssignment", "error", err)
+					continue
 				} else {
 					endpoints = claToEndpoints(&cla)
 					logger.Debug("xDS endpoints updated", slog.Any("endpoints", endpoints))

--- a/internal/xds/client_test.go
+++ b/internal/xds/client_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"log/slog"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -19,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -27,6 +27,7 @@ import (
 
 func TestXDSClient_NewXDSClient(t *testing.T) {
 	cfg := XDSClientConfig{
+		Logger:    slog.Default(),
 		ServerURI: "test-server:4321",
 		NodeID:    "test-client",
 	}
@@ -39,142 +40,291 @@ func TestXDSClient_NewXDSClient(t *testing.T) {
 	assert.Equal(t, "dns:///test-server:4321", client.conn.CanonicalTarget())
 }
 
-func TestXDSClient_XDSComms(t *testing.T) {
-	client, lis, mocked := setupBufconn()
+func TestXDSClient_GetEndpoints(t *testing.T) {
+	client, lis, mocked := setupBufconn(t)
 	defer lis.Close()
 
-	// First response is empty.
-	cla1, err := anypb.New(&endpoint.ClusterLoadAssignment{
-		Endpoints: []*endpoint.LocalityLbEndpoints{},
-	})
+	// First call to GetEndpoints starts watchEndpoints.
+	_, err := client.GetEndpoints("test-service")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "endpoints not yet discovered for test-service")
+
+	// Response has a single endpoint.
+	endpoints := []Endpoint{{Host: "1.2.3.4", Port: 4321, Weight: 42}}
+	cla, err := makeCLA(endpoints)
 	require.NoError(t, err)
-	// Second response has a single endpoint.
-	cla2, err := anypb.New(&endpoint.ClusterLoadAssignment{
-		Endpoints: []*endpoint.LocalityLbEndpoints{
-			{
-				LbEndpoints: []*endpoint.LbEndpoint{
-					{
-						HostIdentifier: &endpoint.LbEndpoint_Endpoint{
-							Endpoint: &endpoint.Endpoint{
-								Address: &core.Address{
-									Address: &core.Address_SocketAddress{
-										SocketAddress: &core.SocketAddress{
-											Address: "1.2.3.4",
-											PortSpecifier: &core.SocketAddress_PortValue{
-												PortValue: 4321,
-											},
+
+	mocked.respond(&discovery.DiscoveryResponse{Resources: []*anypb.Any{cla}})
+
+	assertEndpoints(t, client, endpoints)
+
+	require.NotEmpty(t, mocked.reqs)
+	assert.EqualExportedValues(t, &core.Node{Id: "test-client"}, mocked.reqs[0].Node)
+	assert.EqualExportedValues(t, resource.EndpointType, mocked.reqs[0].TypeUrl)
+	assert.EqualExportedValues(t, []string{"test-service_cluster"}, mocked.reqs[0].ResourceNames)
+}
+
+func TestXDSClient_GetEndpoints_update(t *testing.T) {
+	client, lis, mocked := setupBufconn(t)
+	defer lis.Close()
+
+	// First call to GetEndpoints starts watchEndpoints.
+	_, err := client.GetEndpoints("test-service")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "endpoints not yet discovered for test-service")
+
+	// First response has a single endpoint.
+	endpoints := []Endpoint{{Host: "1.2.3.4", Port: 4321, Weight: 42}}
+	cla, err := makeCLA(endpoints)
+	require.NoError(t, err)
+
+	mocked.respond(&discovery.DiscoveryResponse{Resources: []*anypb.Any{cla}})
+
+	assertEndpoints(t, client, endpoints)
+
+	// Second response adds a second endpoint.
+	endpoints = []Endpoint{
+		{Host: "1.2.3.4", Port: 4321, Weight: 42},
+		{Host: "1.2.3.5", Port: 4322, Weight: 43},
+	}
+	cla, err = makeCLA(endpoints)
+	require.NoError(t, err)
+
+	mocked.respond(&discovery.DiscoveryResponse{Resources: []*anypb.Any{cla}})
+
+	assertEndpoints(t, client, endpoints)
+	time.Sleep(1 * time.Second)
+}
+
+func TestXDSClient_GetEndpoints_noEndpoints(t *testing.T) {
+	client, lis, mocked := setupBufconn(t)
+	defer lis.Close()
+
+	// First call to GetEndpoints starts watchEndpoints.
+	_, err := client.GetEndpoints("test-service")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "endpoints not yet discovered for test-service")
+
+	// Response has a single endpoint.
+	endpoints := []Endpoint{{Host: "1.2.3.4", Port: 4321, Weight: 42}}
+	cla, err := makeCLA(endpoints)
+	require.NoError(t, err)
+
+	mocked.respond(&discovery.DiscoveryResponse{Resources: []*anypb.Any{cla}})
+
+	assertEndpoints(t, client, endpoints)
+
+	// Send a response with no endpoints
+	emptyCLA, err := makeCLA(nil)
+	require.NoError(t, err)
+	mocked.respond(&discovery.DiscoveryResponse{Resources: []*anypb.Any{emptyCLA}})
+
+	// Endpoints should be removed from cache.
+	assertEndpoints(t, client, []Endpoint{})
+
+	// Replace endpoints in response.
+	mocked.respond(&discovery.DiscoveryResponse{Resources: []*anypb.Any{cla}})
+
+	// Endpoints should be replaced in cache.
+	assertEndpoints(t, client, endpoints)
+}
+
+func TestXDSClient_GetEndpoints_noResources(t *testing.T) {
+	client, lis, mocked := setupBufconn(t)
+	defer lis.Close()
+
+	// First call to GetEndpoints starts watchEndpoints.
+	_, err := client.GetEndpoints("test-service")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "endpoints not yet discovered for test-service")
+
+	// Response has a single endpoint.
+	endpoints := []Endpoint{{Host: "1.2.3.4", Port: 4321, Weight: 42}}
+	cla, err := makeCLA(endpoints)
+	require.NoError(t, err)
+
+	// Initial response has no resources.
+	mocked.respond(&discovery.DiscoveryResponse{Resources: []*anypb.Any{}})
+	// Second response has an endpoint.
+	mocked.respond(&discovery.DiscoveryResponse{Resources: []*anypb.Any{cla}})
+
+	assertEndpoints(t, client, endpoints)
+
+	// Send a response with no resources.
+	mocked.respond(&discovery.DiscoveryResponse{Resources: []*anypb.Any{}})
+
+	// Endpoints should be removed from cache.
+	assertEndpoints(t, client, []Endpoint{})
+
+	// Replace resources in response.
+	cla, err = makeCLA(endpoints)
+	require.NoError(t, err)
+	mocked.respond(&discovery.DiscoveryResponse{Resources: []*anypb.Any{cla}})
+
+	// Endpoints should be replaced in cache.
+	assertEndpoints(t, client, endpoints)
+}
+
+func TestXDSClient_GetEndpoints_sendError(t *testing.T) {
+	client, lis, mocked := setupBufconn(t)
+	defer lis.Close()
+
+	// First call to GetEndpoints starts watchEndpoints.
+	_, err := client.GetEndpoints("test-service")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "endpoints not yet discovered for test-service")
+
+	// First client call to Send returns an error.
+	// The channel is blocking, so we know this will be consumed before the response.
+	mocked.error(errors.New("failed to open stream"))
+
+	// Then respond with a single endpoint.
+	endpoints := []Endpoint{{Host: "1.2.3.4", Port: 4321, Weight: 42}}
+	cla, err := makeCLA(endpoints)
+	require.NoError(t, err)
+
+	mocked.respond(&discovery.DiscoveryResponse{Resources: []*anypb.Any{cla}})
+
+	assertEndpoints(t, client, endpoints)
+}
+
+// makeCLA returns a ClusterLoadAssignment for a slice of Endpoint, encoded as an anypb.Any.
+func makeCLA(endpoints []Endpoint) (*anypb.Any, error) {
+	localityEps := []*endpoint.LocalityLbEndpoints{}
+	for _, ep := range endpoints {
+		localityEps = append(localityEps, &endpoint.LocalityLbEndpoints{
+			LbEndpoints: []*endpoint.LbEndpoint{
+				{
+					HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+						Endpoint: &endpoint.Endpoint{
+							Address: &core.Address{
+								Address: &core.Address_SocketAddress{
+									SocketAddress: &core.SocketAddress{
+										Address: ep.Host,
+										PortSpecifier: &core.SocketAddress_PortValue{
+											PortValue: uint32(ep.Port),
 										},
 									},
 								},
 							},
 						},
-						LoadBalancingWeight: &wrapperspb.UInt32Value{
-							Value: 42,
-						},
+					},
+					LoadBalancingWeight: &wrapperspb.UInt32Value{
+						Value: uint32(ep.Weight),
 					},
 				},
 			},
-		},
-	})
-	require.NoError(t, err)
-
-	mocked.resps = []*discovery.DiscoveryResponse{
-		{Resources: []*anypb.Any{cla1}},
-		{Resources: []*anypb.Any{cla2}},
+		})
 	}
+	return anypb.New(&endpoint.ClusterLoadAssignment{Endpoints: localityEps})
+}
 
-	mocked.errs = []error{errors.New("no spoons"), errors.New("lost my wallet")}
-
-	_, err = client.GetEndpoints("test-service")
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "endpoints not yet discovered for test-service")
-
+// assertEndpoints asserts that the client eventually returns the specified endpoints from GetEndpoints.
+func assertEndpoints(t *testing.T, client *XDSClient, endpoints []Endpoint) {
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		endpoints, err := client.GetEndpoints("test-service")
+		got, err := client.GetEndpoints("test-service")
 		require.NoError(collect, err)
-		expected := []Endpoint{{Host: "1.2.3.4", Port: 4321, Weight: 42}}
-		assert.Equal(collect, expected, endpoints)
+		assert.Equal(collect, endpoints, got)
 	}, 10*time.Second, 100*time.Millisecond)
-
-	assert.NotNil(t, mocked.req)
-	assert.EqualExportedValues(t, &core.Node{Id: "test-client"}, mocked.req.Node)
-	assert.EqualExportedValues(t, resource.EndpointType, mocked.req.TypeUrl)
-	assert.EqualExportedValues(t, []string{"test-service_cluster"}, mocked.req.ResourceNames)
-
 }
 
 type MockAggregatedDiscoveryService struct {
 	discoveryv3.UnimplementedAggregatedDiscoveryServiceServer
-	req   *discovery.DiscoveryRequest
-	resps []*discovery.DiscoveryResponse
-	errs  []error
+	t      *testing.T
+	reqs   []*discovery.DiscoveryRequest
+	respCh chan *discovery.DiscoveryResponse
+	errCh  chan error
+}
+
+func newMockAggregatedDiscoveryService(t *testing.T) *MockAggregatedDiscoveryService {
+	return &MockAggregatedDiscoveryService{
+		t:      t,
+		respCh: make(chan *discoveryv3.DiscoveryResponse),
+		errCh:  make(chan error),
+	}
 }
 
 func (m *MockAggregatedDiscoveryService) StreamAggregatedResources(
 	stream discoveryv3.AggregatedDiscoveryService_StreamAggregatedResourcesServer,
 ) error {
-	// Allow injection of errors
-	if len(m.errs) > 0 {
-		err := m.errs[0]
-		m.errs = m.errs[1:]
-		return err
-	}
+	for {
+		// Wait for a DiscoveryRequest
+		req, err := stream.Recv()
+		if err != nil {
+			return err
+		}
 
-	req, err := stream.Recv()
-	if err != nil {
-		return err
-	}
+		m.reqs = append(m.reqs, req)
 
-	// Record the request
-	m.req = req
-
-	// Stream each response in turn
-	for _, resp := range m.resps {
-		if err := stream.Send(resp); err != nil {
+		// Wait for the test harness to send us either a response or error to return to the client.
+		select {
+		case resp, ok := <-m.respCh:
+			if !ok {
+				return nil
+			}
+			if err := stream.Send(resp); err != nil {
+				return err
+			}
+		case err := <-m.errCh:
 			return err
 		}
 	}
+}
 
-	return nil
+// respond sends a response on respCh for the server to send to the client.
+func (m *MockAggregatedDiscoveryService) respond(resp *discovery.DiscoveryResponse) {
+	select {
+	case m.respCh <- resp:
+	case <-time.After(5 * time.Second):
+		m.t.Fatal("Timed out waiting to send to response channel")
+	}
+}
+
+// error sends an error on errCh for the server to send to the client.
+func (m *MockAggregatedDiscoveryService) error(err error) {
+	select {
+	case m.errCh <- err:
+	case <-time.After(5 * time.Second):
+		m.t.Fatal("Timed out waiting to send to error channel")
+	}
 }
 
 // setupBufconn creates a bufconn-enabled grpc server with a mock ADS implementation
 // for unit test usage when testing the cofide-sdk-go xDS functionality
-func setupBufconn() (*XDSClient, *bufconn.Listener, *MockAggregatedDiscoveryService) {
+func setupBufconn(t *testing.T, opts ...grpc.DialOption) (*XDSClient, *bufconn.Listener, *MockAggregatedDiscoveryService) {
 	lis := bufconn.Listen(1024 * 1024)
 	srv := grpc.NewServer()
-	mockADSService := &MockAggregatedDiscoveryService{}
+	mockADSService := newMockAggregatedDiscoveryService(t)
 	discoveryv3.RegisterAggregatedDiscoveryServiceServer(srv, mockADSService)
 
 	go func() {
-		if err := srv.Serve(lis); err != nil {
-			panic(err)
-		}
+		_ = srv.Serve(lis)
 	}()
 
 	cfg := XDSClientConfig{
+		Logger: makeLogger(),
 		// NB: passthrough is required to avoid dns resolution
 		ServerURI: "passthrough:///test-server",
 		NodeID:    "test-client",
 	}
 
-	conn, _ := grpc.NewClient(
-		cfg.ServerURI,
-		grpc.WithContextDialer(
+	if len(opts) == 0 {
+		opts = []grpc.DialOption{grpc.WithContextDialer(
 			func(context.Context, string) (net.Conn, error) {
 				return lis.Dial()
 			},
-		),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-
-	client := &XDSClient{
-		conn:   conn,
-		client: discovery.NewAggregatedDiscoveryServiceClient(conn),
-		nodeID: cfg.NodeID,
+		)}
 	}
+	client, err := NewXDSClient(cfg, opts...)
+	require.NoError(t, err)
 
-	slog.Info("running bufconn test server", "target", conn.Target())
+	slog.Debug("running bufconn test server", "target", client.conn.Target())
 
 	return client, lis, mockADSService
+}
+
+// makeLogger returns a Logger that sends logs to stderr.
+func makeLogger() *slog.Logger {
+	opts := &slog.HandlerOptions{Level: slog.LevelInfo}
+	return slog.New(slog.NewTextHandler(os.Stderr, opts))
 }


### PR DESCRIPTION
Previously, the xDS client did not receive updates after the first
response. This could cause problems if the endpoint resources change, or
if they are not present in the initial response, e.g. due to a race.

The problem is that the xDS server loop waits until it receives a
DiscoveryRequest before sending a DiscoveryResponse.

This change fixes the issue by sending a DiscoveryRequest after each
response is received, updating it with the last seen version and
response nonce.

This change also improves unit test coverage, including testing for the
issue being addressed here.

Fixes: #16
