### PR TITLE
feat: add Credex OAuth token source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ go 1.25.7
 require (
 	github.com/envoyproxy/go-control-plane v0.14.0
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/gobwas/glob v0.2.3
 	github.com/spiffe/go-spiffe/v2 v2.6.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/oauth2 v0.36.0
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 )
@@ -18,7 +20,6 @@ require (
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=

--- a/oauth/credex/credex.go
+++ b/oauth/credex/credex.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package credex obtains OAuth 2.0 access tokens from Credex using a SPIFFE
+// JWT-SVID. The returned token sources integrate with golang.org/x/oauth2.
+package credex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"golang.org/x/oauth2"
+)
+
+const (
+	grantTypeTokenExchange    = "urn:ietf:params:oauth:grant-type:token-exchange"
+	clientAssertionJWTSpiffe  = "urn:ietf:params:oauth:client-assertion-type:jwt-spiffe"
+	tokenTypeJWTSpiffe        = "urn:ietf:params:oauth:token-type:jwt_spiffe"
+	defaultEarlyExpiry        = 10 * time.Second
+	maxTokenResponseBodyBytes = 1 << 20
+)
+
+// Config configures an OAuth Bridge exchange through Credex.
+//
+// Credex authenticates the workload using a JWT-SVID, obtains an access token
+// from the downstream authorization server selected by policy, and returns
+// that token unchanged.
+type Config struct {
+	// TokenURL is the Credex OAuth token endpoint.
+	TokenURL string
+
+	// Audience is the target audience requested from the downstream
+	// authorization server. Credex uses it, together with Scopes and the
+	// workload identity, when selecting an exchange policy.
+	Audience string
+
+	// Scopes are the OAuth scopes requested from the downstream authorization
+	// server.
+	Scopes []string
+
+	// HTTPClient is used to call the Credex token endpoint. When nil,
+	// http.DefaultClient is used.
+	HTTPClient *http.Client
+
+	// EarlyExpiry controls how early a cached access token is refreshed. When
+	// zero, a ten-second safety margin is used.
+	EarlyExpiry time.Duration
+}
+
+// TokenSource returns an oauth2.TokenSource which obtains and refreshes access
+// tokens through Credex. The source is safe for concurrent use.
+//
+// The caller owns source and must close it when it is also an io.Closer, as is
+// the case for workloadapi.JWTSource.
+func (c *Config) TokenSource(ctx context.Context, source jwtsvid.Source) (oauth2.TokenSource, error) {
+	if ctx == nil {
+		return nil, errors.New("credex: context is nil")
+	}
+	if source == nil {
+		return nil, errors.New("credex: JWT-SVID source is nil")
+	}
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	sourceImpl := &tokenSource{
+		ctx:        ctx,
+		svidSource: source,
+		httpClient: httpClient,
+		tokenURL:   c.TokenURL,
+		audience:   c.Audience,
+		scopes:     append([]string(nil), c.Scopes...),
+	}
+
+	earlyExpiry := c.EarlyExpiry
+	if earlyExpiry == 0 {
+		earlyExpiry = defaultEarlyExpiry
+	}
+
+	return oauth2.ReuseTokenSourceWithExpiry(nil, sourceImpl, earlyExpiry), nil
+}
+
+// Client returns an HTTP client which obtains bearer tokens from Credex and
+// refreshes them as required. The client is valid for the lifetime of ctx.
+func (c *Config) Client(ctx context.Context, source jwtsvid.Source) (*http.Client, error) {
+	tokenSource, err := c.TokenSource(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+	return oauth2.NewClient(ctx, tokenSource), nil
+}
+
+func (c *Config) validate() error {
+	if c == nil {
+		return errors.New("credex: config is nil")
+	}
+	if c.TokenURL == "" {
+		return errors.New("credex: token URL is required")
+	}
+	parsed, err := url.Parse(c.TokenURL)
+	if err != nil {
+		return fmt.Errorf("credex: invalid token URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return errors.New("credex: token URL must use http or https")
+	}
+	if parsed.Host == "" {
+		return errors.New("credex: token URL must be absolute")
+	}
+	if c.EarlyExpiry < 0 {
+		return errors.New("credex: early expiry must not be negative")
+	}
+	for _, scope := range c.Scopes {
+		if scope == "" || strings.ContainsAny(scope, " \t\r\n") {
+			return fmt.Errorf("credex: invalid scope %q", scope)
+		}
+	}
+	return nil
+}
+
+type tokenSource struct {
+	ctx        context.Context
+	svidSource jwtsvid.Source
+	httpClient *http.Client
+	tokenURL   string
+	audience   string
+	scopes     []string
+}
+
+func (s *tokenSource) Token() (*oauth2.Token, error) {
+	svid, err := s.svidSource.FetchJWTSVID(s.ctx, jwtsvid.Params{Audience: s.tokenURL})
+	if err != nil {
+		return nil, fmt.Errorf("credex: fetching JWT-SVID: %w", err)
+	}
+	if svid == nil || svid.Marshal() == "" {
+		return nil, errors.New("credex: JWT-SVID source returned an empty SVID")
+	}
+
+	encodedSVID := svid.Marshal()
+	form := url.Values{
+		"grant_type":            {grantTypeTokenExchange},
+		"client_assertion_type": {clientAssertionJWTSpiffe},
+		"client_assertion":      {encodedSVID},
+		"subject_token":         {encodedSVID},
+		"subject_token_type":    {tokenTypeJWTSpiffe},
+	}
+	if s.audience != "" {
+		form.Set("audience", s.audience)
+	}
+	if len(s.scopes) > 0 {
+		form.Set("scope", strings.Join(s.scopes, " "))
+	}
+
+	req, err := http.NewRequestWithContext(s.ctx, http.MethodPost, s.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("credex: building token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("credex: requesting token: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxTokenResponseBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("credex: reading token response: %w", err)
+	}
+	if len(body) > maxTokenResponseBodyBytes {
+		return nil, errors.New("credex: token response exceeds 1 MiB")
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, newRetrieveError(resp, body)
+	}
+
+	var wire tokenResponse
+	if err := json.Unmarshal(body, &wire); err != nil {
+		return nil, fmt.Errorf("credex: decoding token response: %w", err)
+	}
+	if wire.Error != "" {
+		return nil, newRetrieveError(resp, body)
+	}
+	if wire.AccessToken == "" {
+		return nil, errors.New("credex: token response is missing access_token")
+	}
+	if wire.ExpiresIn < 0 {
+		return nil, errors.New("credex: token response contains a negative expires_in")
+	}
+
+	token := &oauth2.Token{
+		AccessToken: wire.AccessToken,
+		TokenType:   wire.TokenType,
+		ExpiresIn:   wire.ExpiresIn,
+	}
+	if wire.ExpiresIn > 0 {
+		token.Expiry = time.Now().Add(time.Duration(wire.ExpiresIn) * time.Second)
+	}
+
+	return token.WithExtra(map[string]any{
+		"scope":             wire.Scope,
+		"issued_token_type": wire.IssuedTokenType,
+	}), nil
+}
+
+type tokenResponse struct {
+	AccessToken      string `json:"access_token"`
+	TokenType        string `json:"token_type"`
+	ExpiresIn        int64  `json:"expires_in"`
+	Scope            string `json:"scope"`
+	IssuedTokenType  string `json:"issued_token_type"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+	ErrorURI         string `json:"error_uri"`
+}
+
+func newRetrieveError(resp *http.Response, body []byte) *oauth2.RetrieveError {
+	var wire tokenResponse
+	_ = json.Unmarshal(body, &wire)
+	return &oauth2.RetrieveError{
+		Response:         resp,
+		Body:             body,
+		ErrorCode:        wire.Error,
+		ErrorDescription: wire.ErrorDescription,
+		ErrorURI:         wire.ErrorURI,
+	}
+}

--- a/oauth/credex/credex.go
+++ b/oauth/credex/credex.go
@@ -37,6 +37,12 @@ type Config struct {
 	// TokenURL is the Credex OAuth token endpoint.
 	TokenURL string
 
+	// JWTSVIDAudience is the audience used when fetching the JWT-SVID that
+	// authenticates the workload to Credex. When empty, TokenURL is used. Set
+	// this when the externally advertised token endpoint differs from the URL
+	// used to reach Credex from the workload's network.
+	JWTSVIDAudience string
+
 	// Audience is the target audience requested from the downstream
 	// authorization server. Credex uses it, together with Scopes and the
 	// workload identity, when selecting an exchange policy.
@@ -77,12 +83,13 @@ func (c *Config) TokenSource(ctx context.Context, source jwtsvid.Source) (oauth2
 	}
 
 	sourceImpl := &tokenSource{
-		ctx:        ctx,
-		svidSource: source,
-		httpClient: httpClient,
-		tokenURL:   c.TokenURL,
-		audience:   c.Audience,
-		scopes:     append([]string(nil), c.Scopes...),
+		ctx:             ctx,
+		svidSource:      source,
+		httpClient:      httpClient,
+		tokenURL:        c.TokenURL,
+		jwtSVIDAudience: c.jwtSVIDAudience(),
+		audience:        c.Audience,
+		scopes:          append([]string(nil), c.Scopes...),
 	}
 
 	earlyExpiry := c.EarlyExpiry
@@ -91,6 +98,13 @@ func (c *Config) TokenSource(ctx context.Context, source jwtsvid.Source) (oauth2
 	}
 
 	return oauth2.ReuseTokenSourceWithExpiry(nil, sourceImpl, earlyExpiry), nil
+}
+
+func (c *Config) jwtSVIDAudience() string {
+	if c.JWTSVIDAudience != "" {
+		return c.JWTSVIDAudience
+	}
+	return c.TokenURL
 }
 
 // Client returns an HTTP client which obtains bearer tokens from Credex and
@@ -132,16 +146,17 @@ func (c *Config) validate() error {
 }
 
 type tokenSource struct {
-	ctx        context.Context
-	svidSource jwtsvid.Source
-	httpClient *http.Client
-	tokenURL   string
-	audience   string
-	scopes     []string
+	ctx             context.Context
+	svidSource      jwtsvid.Source
+	httpClient      *http.Client
+	tokenURL        string
+	jwtSVIDAudience string
+	audience        string
+	scopes          []string
 }
 
 func (s *tokenSource) Token() (*oauth2.Token, error) {
-	svid, err := s.svidSource.FetchJWTSVID(s.ctx, jwtsvid.Params{Audience: s.tokenURL})
+	svid, err := s.svidSource.FetchJWTSVID(s.ctx, jwtsvid.Params{Audience: s.jwtSVIDAudience})
 	if err != nil {
 		return nil, fmt.Errorf("credex: fetching JWT-SVID: %w", err)
 	}

--- a/oauth/credex/credex_test.go
+++ b/oauth/credex/credex_test.go
@@ -69,6 +69,25 @@ func TestTokenSourceExchange(t *testing.T) {
 	assert.Equal(t, []string{server.URL}, source.audiences())
 }
 
+func TestTokenSourceSeparateJWTSVIDAudience(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"downstream-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	source := newFakeSVIDSource(t)
+	tokenSource, err := (&credex.Config{
+		TokenURL:        server.URL,
+		JWTSVIDAudience: "https://credex.example.com/token",
+		Audience:        "legacy-api",
+	}).TokenSource(t.Context(), source)
+	require.NoError(t, err)
+
+	_, err = tokenSource.Token()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"https://credex.example.com/token"}, source.audiences())
+}
+
 func TestTokenSourceRefreshesExpiringToken(t *testing.T) {
 	var mu sync.Mutex
 	requests := 0

--- a/oauth/credex/credex_test.go
+++ b/oauth/credex/credex_test.go
@@ -1,0 +1,215 @@
+// Copyright 2026 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package credex_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/cofide/cofide-sdk-go/oauth/credex"
+)
+
+func TestTokenSourceExchange(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		require.Equal(t, "application/json", r.Header.Get("Accept"))
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", r.Form.Get("grant_type"))
+		assert.Equal(t, "urn:ietf:params:oauth:client-assertion-type:jwt-spiffe", r.Form.Get("client_assertion_type"))
+		assert.Equal(t, "urn:ietf:params:oauth:token-type:jwt_spiffe", r.Form.Get("subject_token_type"))
+		assert.Equal(t, r.Form.Get("client_assertion"), r.Form.Get("subject_token"))
+		assert.Equal(t, "legacy-api", r.Form.Get("audience"))
+		assert.Equal(t, "read write", r.Form.Get("scope"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"downstream-token","token_type":"Bearer","expires_in":3600,"scope":"read write","issued_token_type":"urn:ietf:params:oauth:token-type:access_token"}`))
+	}))
+	defer server.Close()
+
+	source := newFakeSVIDSource(t)
+	tokenSource, err := (&credex.Config{
+		TokenURL: server.URL,
+		Audience: "legacy-api",
+		Scopes:   []string{"read", "write"},
+	}).TokenSource(t.Context(), source)
+	require.NoError(t, err)
+
+	before := time.Now()
+	token, err := tokenSource.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "downstream-token", token.AccessToken)
+	assert.Equal(t, "Bearer", token.TokenType)
+	assert.EqualValues(t, 3600, token.ExpiresIn)
+	assert.WithinDuration(t, before.Add(time.Hour), token.Expiry, time.Second)
+	assert.Equal(t, "read write", token.Extra("scope"))
+	assert.Equal(t, "urn:ietf:params:oauth:token-type:access_token", token.Extra("issued_token_type"))
+
+	second, err := tokenSource.Token()
+	require.NoError(t, err)
+	assert.Same(t, token, second)
+	assert.Equal(t, 1, requests)
+	assert.Equal(t, []string{server.URL}, source.audiences())
+}
+
+func TestTokenSourceRefreshesExpiringToken(t *testing.T) {
+	var mu sync.Mutex
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		_, _ = w.Write([]byte(`{"access_token":"short-lived","token_type":"Bearer","expires_in":1}`))
+	}))
+	defer server.Close()
+
+	source := newFakeSVIDSource(t)
+	tokenSource, err := (&credex.Config{
+		TokenURL: server.URL,
+		Audience: "legacy-api",
+	}).TokenSource(t.Context(), source)
+	require.NoError(t, err)
+
+	_, err = tokenSource.Token()
+	require.NoError(t, err)
+	_, err = tokenSource.Token()
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 2, requests)
+}
+
+func TestTokenSourceOAuthError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"access_denied","error_description":"denied by policy"}`))
+	}))
+	defer server.Close()
+
+	tokenSource, err := (&credex.Config{TokenURL: server.URL, Audience: "legacy-api"}).TokenSource(t.Context(), newFakeSVIDSource(t))
+	require.NoError(t, err)
+	_, err = tokenSource.Token()
+
+	var retrieveError *oauth2.RetrieveError
+	require.ErrorAs(t, err, &retrieveError)
+	assert.Equal(t, http.StatusForbidden, retrieveError.Response.StatusCode)
+	assert.Equal(t, "access_denied", retrieveError.ErrorCode)
+	assert.Equal(t, "denied by policy", retrieveError.ErrorDescription)
+}
+
+func TestTokenSourceSVIDError(t *testing.T) {
+	wantErr := errors.New("workload API unavailable")
+	source := &fakeSVIDSource{err: wantErr}
+	tokenSource, err := (&credex.Config{TokenURL: "https://credex.example.com/token", Audience: "legacy-api"}).TokenSource(t.Context(), source)
+	require.NoError(t, err)
+
+	_, err = tokenSource.Token()
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestConfigValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *credex.Config
+		source jwtsvid.Source
+		want   string
+	}{
+		{name: "nil config", source: newFakeSVIDSource(t), want: "config is nil"},
+		{name: "nil context", config: &credex.Config{}, source: newFakeSVIDSource(t), want: "context is nil"},
+		{name: "nil source", config: &credex.Config{}, want: "JWT-SVID source is nil"},
+		{name: "missing token URL", config: &credex.Config{Audience: "api"}, source: newFakeSVIDSource(t), want: "token URL is required"},
+		{name: "relative token URL", config: &credex.Config{TokenURL: "/token", Audience: "api"}, source: newFakeSVIDSource(t), want: "must use http or https"},
+		{name: "negative early expiry", config: &credex.Config{TokenURL: "https://credex.example.com/token", EarlyExpiry: -time.Second}, source: newFakeSVIDSource(t), want: "early expiry must not be negative"},
+		{name: "invalid scope", config: &credex.Config{TokenURL: "https://credex.example.com/token", Audience: "api", Scopes: []string{"read write"}}, source: newFakeSVIDSource(t), want: "invalid scope"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tc.name == "nil context" {
+				ctx = nil
+			}
+			_, err := tc.config.TokenSource(ctx, tc.source)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+func TestClientAddsBearerToken(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			_, _ = w.Write([]byte(`{"access_token":"downstream-token","token_type":"Bearer","expires_in":3600}`))
+		case "/resource":
+			assert.Equal(t, "Bearer downstream-token", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	client, err := (&credex.Config{TokenURL: serverURL + "/token", Audience: "legacy-api"}).Client(t.Context(), newFakeSVIDSource(t))
+	require.NoError(t, err)
+	resp, err := client.Get(serverURL + "/resource")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+type fakeSVIDSource struct {
+	svid *jwtsvid.SVID
+	err  error
+	mu   sync.Mutex
+	auds []string
+}
+
+func newFakeSVIDSource(t *testing.T) *fakeSVIDSource {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES256, Key: key}, nil)
+	require.NoError(t, err)
+	raw, err := jwt.Signed(signer).Claims(map[string]any{
+		"sub": "spiffe://example.org/workload",
+		"aud": []string{"placeholder"},
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}).Serialize()
+	require.NoError(t, err)
+	svid, err := jwtsvid.ParseInsecure(raw, []string{"placeholder"})
+	require.NoError(t, err)
+	return &fakeSVIDSource{svid: svid}
+}
+
+func (s *fakeSVIDSource) FetchJWTSVID(_ context.Context, params jwtsvid.Params) (*jwtsvid.SVID, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.auds = append(s.auds, params.Audience)
+	return s.svid, s.err
+}
+
+func (s *fakeSVIDSource) audiences() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.auds...)
+}

--- a/oauth/credex/example_test.go
+++ b/oauth/credex/example_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Cofide Limited.
+// SPDX-License-Identifier: Apache-2.0
+
+package credex_test
+
+import (
+	"context"
+	"log"
+
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+
+	"github.com/cofide/cofide-sdk-go/oauth/credex"
+)
+
+func ExampleConfig_Client() {
+	ctx := context.Background()
+
+	jwtSource, err := workloadapi.NewJWTSource(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() { _ = jwtSource.Close() }()
+
+	config := &credex.Config{
+		TokenURL: "https://credex.example.com/token",
+		Audience: "legacy-api",
+		Scopes:   []string{"data:read"},
+	}
+	client, err := config.Client(ctx, jwtSource)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// The client obtains and refreshes a downstream OAuth access token through
+	// Credex, then adds it to requests as an Authorization bearer token.
+	_, _ = client.Get("https://legacy-api.example.com/data")
+}


### PR DESCRIPTION
## What changed

- add a Credex-backed `golang.org/x/oauth2.TokenSource`
- fetch a JWT-SVID and perform an RFC 8693 impersonation exchange through Credex
- cache and refresh downstream access tokens using the standard Go OAuth transport
- provide a convenience authenticated HTTP client and workload API example
- allow the network `TokenURL` and advertised `JWTSVIDAudience` to differ, defaulting the latter to `TokenURL`
- cover request construction, caching, refresh, separate endpoint/audience routing, OAuth errors, SVID errors, validation, and bearer injection

## Why

SPIFFE workloads need an idiomatic way to obtain OAuth access tokens through Credex without manually constructing RFC 8693 requests. Exposing a standard `oauth2.TokenSource` keeps token reuse and authenticated HTTP behavior compatible with the core Go OAuth libraries.

Credex may advertise a token endpoint URL that is correct as the client-assertion audience but not routable from every workload network. Keeping request routing separate from the JWT-SVID audience supports split-horizon and in-cluster deployments without weakening audience validation.

## Validation

- `go test ./...`
- `go test -race ./oauth/credex`
- `go vet ./...`
- `git diff --check`
